### PR TITLE
Use physically based line rendering from woscope

### DIFF
--- a/bin/data/shaders/osci.frag
+++ b/bin/data/shaders/osci.frag
@@ -1,13 +1,42 @@
-#version 120  
+#define EPS 1E-6
+#define TAU 6.283185307179586
+#define TAUR 2.5066282746310002
+#define SQRT2 1.4142135623730951
+uniform float uSize;
+uniform float uIntensity;
 
-uniform sampler2DRect tex;
-varying vec2 texcoord;
+varying vec3 texcoord;
 
-void main(void)  
-{  
-	vec4 col = texture2DRect(tex, vec2(texcoord.x*20,texcoord.y*20)); 
-    gl_FragColor = gl_Color*col;
-	gl_FragColor.a *= 10;
-//	gl_FragColor = vec4(texcoord.x,texcoord.y,0,1);
-//	gl_FragColor = gl_Color; 
-}  
+float gaussian(float x, float sigma) {
+    return exp(-(x * x) / (2.0 * sigma * sigma)) / (TAUR * sigma);
+}
+
+float erf(float x) {
+    float s = sign(x), a = abs(x);
+    x = 1.0 + (0.278393 + (0.230389 + (0.000972 + 0.078108 * a) * a) * a) * a;
+    x *= x;
+    return s - s / (x * x);
+}
+
+void main (void)
+{
+    float len = texcoord.z;
+    vec2 xy = texcoord.xy;
+    float alpha;
+
+    float sigma = uSize/4.0;
+    if (len < EPS) {
+    // If the beam segment is too short, just calculate intensity at the position.
+        alpha = exp(-pow(length(xy),2.0)/(2.0*sigma*sigma))/2.0/sqrt(uSize);
+    } else {
+    // Otherwise, use analytical integral for accumulated intensity.
+        alpha = erf(xy.x/SQRT2/sigma) - erf((xy.x-len)/SQRT2/sigma);
+        alpha *= exp(-xy.y*xy.y/(2.0*sigma*sigma))/2.0/len*uSize;
+    }
+
+    alpha *= uIntensity;
+
+    //float afterglow = smoothstep(0.0, 0.33, uvl.w/2048.0);
+    //alpha *= afterglow * 1.0;
+    gl_FragColor = vec4(1./32., 1.0, 1./32., alpha);
+}

--- a/bin/data/shaders/osci.geom
+++ b/bin/data/shaders/osci.geom
@@ -1,41 +1,44 @@
-#extension GL_EXT_geometry_shader4 : enable  
-varying out vec2 texcoord;
+#version 120
+#extension GL_EXT_geometry_shader4 : enable
+#define EPS 1E-6
 
+varying vec3 texcoord;
+uniform float uSize;
+uniform mat3 uMatrix;
 
-//layout(points) in;  
-//layout(quads, max_vertices = 4) out;  
+void main() {
+    mat4 tmatrix = mat4(uMatrix);
+    vec2 p0 = (gl_PositionIn[0]).xy;
+    vec2 p1 = (gl_PositionIn[1]).xy;
+    vec2 dir = p1 - p0;
+    texcoord.z = length(dir);
 
-uniform float height;  
-uniform float width;  
+    if (texcoord.z > EPS) {
+        dir = dir / texcoord.z;
+    } else {
+        dir = vec2(1.0, 0.0);
+    }
 
-void main() {  
-	gl_PositionIn[0];  
-	float w = width*1.0;
-	// shit? !
-	float h = w*16.0/10.0; 
-	
+    vec2 norm = vec2(-dir.y, dir.x);
 
-	texcoord=vec2(0,0);
-	gl_FrontColor = gl_FrontColorIn[0]; 
-	gl_Position = gl_PositionIn[0]+vec4(0,0,0,0);
-	EmitVertex();  
+    gl_FrontColor = gl_FrontColorIn[0];
 
-	texcoord=vec2(0,1);
-	gl_FrontColor = gl_FrontColorIn[0]; 
-	gl_Position = gl_PositionIn[0]+vec4(0,h,0,0);
-	EmitVertex();  
+    dir *= uSize;
+    norm *= uSize;
 
+    texcoord.xy = vec2(-uSize, -uSize);
+    gl_Position = tmatrix * vec4(p0 - dir - norm, 0.0, 1.0);
+    EmitVertex();
 
-	texcoord=vec2(1,0);
-	gl_FrontColor = gl_FrontColorIn[0]; 
-	gl_Position = gl_PositionIn[0]+vec4(w,0,0,0);
-	EmitVertex();  
+    texcoord.xy = vec2(-uSize,  uSize);
+    gl_Position = tmatrix * vec4(p0 - dir + norm, 0.0, 1.0);
+    EmitVertex();
 
-	texcoord=vec2(1,1);
-	gl_FrontColor = gl_FrontColorIn[0]; 
-	gl_Position = gl_PositionIn[0]+vec4(w,h,0,0);
-	EmitVertex();  
+    texcoord.xy = vec2(texcoord.z + uSize, -uSize);
+    gl_Position = tmatrix * vec4(p1 + dir - norm, 0.0, 1.0);
+    EmitVertex();
 
-	// output  
-	EndPrimitive();  
-}  
+    texcoord.xy = vec2(texcoord.z + uSize,  uSize);
+    gl_Position = tmatrix * vec4(p1 + dir + norm, 0.0, 1.0);
+    EmitVertex();
+}

--- a/bin/data/shaders/osci.vert
+++ b/bin/data/shaders/osci.vert
@@ -1,6 +1,7 @@
 #version 110
-void main()  
-{  
-	gl_FrontColor = gl_Color;  
-	gl_Position = gl_ModelViewProjectionMatrix* gl_Vertex;  
-}  
+uniform mat3 uMatrix;
+void main()
+{
+	gl_FrontColor = gl_Color;
+	gl_Position = gl_Vertex;
+}

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -33,6 +33,8 @@ class ofApp : public ofBaseApp{
 		
 		void audioIn(float * input, int bufferSize, int nChannels);
 		void audioOut( float * output, int bufferSize, int nChannels ); 
+
+		ofMatrix3x3 getViewMatrix();
 	
 		ofSoundStream soundStream;
 
@@ -41,7 +43,6 @@ class ofApp : public ofBaseApp{
 		OsciView * osciView;
 		ofPath path;
 		ofMesh shapeMesh;
-		ofImage dotImage;
 		ofFbo fbo, fbb;
 		ofShader shader;
 		ShaderLoader shaderLoader;


### PR DESCRIPTION
Implemented better line rendering for oscilloscope.
Geometry shader is used to transform `GL_LINES` to `GL_QUADS` which are then rasterized using a magic formula.

Full explanation for the method is available here: http://m1el.github.io/woscope-how/

As a side note I'd like to note that I spent two days trying to build this thing, then a day collecting the missing pieces from the repo, and a few hour actually implementing the feature.

Build instructions, and complete data required for the program would be nice to have.