### PR TITLE
Proper License information (and errata?)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,27 @@
-MIT License
+Copyright (c) 2017 Hansi Raber
 
-Copyright (c) 2017 hansi raber
+           DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
+
+
+ Original Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
+
+
+Based on Openframeworks, a creative coding library for C++.
+The larger part of it is licensed as MIT/BSD.
+
+Copyright (c) 2010, 2011 ofxKinect Team
+
+The MIT License <http://www.opensource.org/licenses/mit-license.php>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +30,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -19,8 +19,15 @@ Copyright (c) 2017 Hansi Raber
 Based on Openframeworks, a creative coding library for C++.
 The larger part of it is licensed as MIT/BSD.
 
-Copyright (c) 2010, 2011 ofxKinect Team
+Copyright (c) 2004 - openFrameworks Community
 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Copyright (c) 2010, 2011 
 The MIT License <http://www.opensource.org/licenses/mit-license.php>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/docs/ffmpeg/license.md
+++ b/docs/ffmpeg/license.md
@@ -1,0 +1,112 @@
+#FFmpeg:
+
+Most files in FFmpeg are under the GNU Lesser General Public License version 2.1
+or later (LGPL v2.1+). Read the file `COPYING.LGPLv2.1` for details. Some other
+files have MIT/X11/BSD-style licenses. In combination the LGPL v2.1+ applies to
+FFmpeg.
+
+Some optional parts of FFmpeg are licensed under the GNU General Public License
+version 2 or later (GPL v2+). See the file `COPYING.GPLv2` for details. None of
+these parts are used by default, you have to explicitly pass `--enable-gpl` to
+configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
+
+Specifically, the GPL parts of FFmpeg are:
+
+- libpostproc
+- optional x86 optimizations in the files
+  - `libavcodec/x86/flac_dsp_gpl.asm`
+  - `libavcodec/x86/idct_mmx.c`
+- libutvideo encoding/decoding wrappers in
+  `libavcodec/libutvideo*.cpp`
+- the X11 grabber in `libavdevice/x11grab.c`
+- the swresample test app in
+  `libswresample/swresample-test.c`
+- the `texi2pod.pl` tool
+- the following filters in libavfilter:
+    - `f_ebur128.c`
+    - `vf_blackframe.c`
+    - `vf_boxblur.c`
+    - `vf_colormatrix.c`
+    - `vf_cover_rect.c`
+    - `vf_cropdetect.c`
+    - `vf_delogo.c`
+    - `vf_eq.c`
+    - `vf_find_rect.c`
+    - `vf_fspp.c`
+    - `vf_geq.c`
+    - `vf_histeq.c`
+    - `vf_hqdn3d.c`
+    - `vf_interlace.c`
+    - `vf_kerndeint.c`
+    - `vf_mcdeint.c`
+    - `vf_mpdecimate.c`
+    - `vf_owdenoise.c`
+    - `vf_perspective.c`
+    - `vf_phase.c`
+    - `vf_pp.c`
+    - `vf_pp7.c`
+    - `vf_pullup.c`
+    - `vf_sab.c`
+    - `vf_smartblur.c`
+    - `vf_repeatfields.c`
+    - `vf_spp.c`
+    - `vf_stereo3d.c`
+    - `vf_super2xsai.c`
+    - `vf_tinterlace.c`
+    - `vf_uspp.c`
+    - `vsrc_mptestsrc.c`
+
+Should you, for whatever reason, prefer to use version 3 of the (L)GPL, then
+the configure parameter `--enable-version3` will activate this licensing option
+for you. Read the file `COPYING.LGPLv3` or, if you have enabled GPL parts,
+`COPYING.GPLv3` to learn the exact legal terms that apply in this case.
+
+There are a handful of files under other licensing terms, namely:
+
+* The files `libavcodec/jfdctfst.c`, `libavcodec/jfdctint_template.c` and
+  `libavcodec/jrevdct.c` are taken from libjpeg, see the top of the files for
+  licensing details. Specifically note that you must credit the IJG in the
+  documentation accompanying your program if you only distribute executables.
+  You must also indicate any changes including additions and deletions to
+  those three files in the documentation.
+* `tests/reference.pnm` is under the expat license.
+
+
+external libraries
+==================
+
+FFmpeg can be combined with a number of external libraries, which sometimes
+affect the licensing of binaries resulting from the combination.
+
+compatible libraries
+--------------------
+
+The following libraries are under GPL:
+- frei0r
+- libcdio
+- libutvideo
+- libvidstab
+- libx264
+- libx265
+- libxavs
+- libxvid
+
+When combining them with FFmpeg, FFmpeg needs to be licensed as GPL as well by
+passing `--enable-gpl` to configure.
+
+The OpenCORE and VisualOn libraries are under the Apache License 2.0. That
+license is incompatible with the LGPL v2.1 and the GPL v2, but not with
+version 3 of those licenses. So to combine these libraries with FFmpeg, the
+license version needs to be upgraded by passing `--enable-version3` to configure.
+
+incompatible libraries
+----------------------
+
+The Fraunhofer AAC library, FAAC and aacplus are under licenses which
+are incompatible with the GPLv2 and v3. We do not know for certain if their
+licenses are compatible with the LGPL.
+If you wish to enable these libraries, pass `--enable-nonfree` to configure.
+But note that if you enable any of these libraries the resulting binary will
+be under a complex license mix that is more restrictive than the LGPL and that
+may result in additional obligations. It is possible that these
+restrictions cause the resulting binary to be unredistributeable.

--- a/docs/ffmpeg/notes.md
+++ b/docs/ffmpeg/notes.md
@@ -1,0 +1,146 @@
+Useful infos for compiling FFmpeg/libavcodec
+===
+
+
+Links
+---
+
+* The [compilation guide](https://trac.ffmpeg.org/wiki/CompilationGuide) official contains instructions for virtually all platforms. 
+* Shared libraries for Windows: [http://ffmpeg.zeranoe.com/builds/](http://ffmpeg.zeranoe.com/builds/)
+* Git repo with full source: git://source.ffmpeg.org/ffmpeg.git or from [https://github.com/FFmpeg/FFmpeg](https://github.com/FFmpeg/FFmpeg)
+* Included binaries were built from commit [https://github.com/FFmpeg/FFmpeg/commit/d5fcca83b915df9536d595a1a44c24294b606836](https://github.com/FFmpeg/FFmpeg/commit/d5fcca83b915df9536d595a1a44c24294b606836)
+* Lots of information about when which codec is built and which configure flags are required: https://www.ffmpeg.org/ffmpeg-codecs.html
+
+Command Line
+---
+
+* ./configure --help will list a lot of options and their current values (eg. --enable-libgsm          enable GSM de/encoding via libgsm [no])
+* `ffmpeg -codecs` to list of installed codecs
+* `./configure --list-decoders` to list available decoders
+* `./configure --list-encoders` to list available encoders
+
+
+Compiling on Mac OS
+---
+The to create a universal binary run the following commands in the ffmpeg source directory: 
+
+	# 1. Build 64 bit
+	make clean
+	./configure  --prefix=`pwd`/dist/ --enable-pic --enable-shared  --shlibdir="@executable_path" --shlibdir="@executable_path" --disable-indevs
+	make && make install
+	mv @executable_path libs_64
+	
+	# 2. Build 32 bit
+	make clean
+	./configure  --prefix=`pwd`/dist/ --enable-pic --enable-shared  --shlibdir="@executable_path" --shlibdir="@executable_path" --disable-indevs --extra-cflags="-m32" --extra-cxxflags="-m32" --extra-ldflags="-m32" --arch=i386
+	make && make install
+	mv @executable_path libs_32
+
+	# 3. Combine dylibs into fat libs and copy over symlinks
+	mkdir libs
+	for file in libs_64/*.dylib
+	do
+		f=$(basename $file)
+		if [ -h $file ];then;cp -av $file libs
+		else;lipo libs_32/$f $file -output libs/$f -create
+		fi
+	done
+	
+	# 4. Clean up a bit to be ready for the next build ... 
+	rm -rf libs_32 libs_64
+	mv libs libs-$(git rev-parse HEAD)
+
+Done! Now copy the include dir to ofxAvCodec/libs/avcodec/include and the libs dir to ofxAvCodec/libs/avcodec/lib/osx
+
+Btw: Directly after running configure you get a neat list of all enabled components like codecs, muxer, and other things I've never heard of. 
+
+
+|Flag|Description|
+|----|-----------|
+|``--prefix=`pwd`/dist/``|Sets the output path to the dist folder|
+|`--enable-pic`|not sure|
+|`--enable-shared`|compile as shared libraries (disables static libs)|
+|`--shlibdir="@executable_path"`|tells each dylib to look for other dylibs in the same folder (i think)|
+|`--disable-indevs`|Disables input devices like qtkit. I added this flag to get rid of the shared lib dependency to jack audio|
+|`--extra-cflags="-m32" --extra-cxxflags="-m32" --extra-ldflags="-m32" --arch=i386`|Create 32 bit binaries|
+
+
+	
+* Copy only the dylibs to libs/avcodec/lib/osx (i copied the symlinks too, but not they're needed)
+* Copy the header directory to libs/avcodec/include
+* Make sure to keep the file libs/avcodec/include/libavutil/inttypes.h
+  It's required for VS2012. This file is licensed as new bsd license. Included from [https://code.google.com/p/msinttypes/](https://code.google.com/p/msinttypes/). In the same folder in common.h replace `#include <inttypes.h>` with `#include "inttypes.h"`. 
+
+
+
+
+Compiling for Windows using Mac OS
+---
+Compiled using the build scripts from [https://github.com/rdp/ffmpeg-windows-build-helpers](https://github.com/rdp/ffmpeg-windows-build-helpers). A great little script that sets up mingw and generates shared libraries. Create a directory `ffmpeg_src/win/` and run 
+	
+	wget https://raw.github.com/rdp/ffmpeg-windows-build-helpers/master/cross_compile_ffmpeg.sh -O cross_compile_ffmpeg.sh
+	./cross_compile_ffmpeg.sh --build-ffmpeg-shared=y --build-ffmpeg-static=n
+
+
+Before doing anything, edit the file and look for the `build_ffmpeg()` function. A few lines into the function you can find the configure options used. I modified them as follows: 
+
+	  #original config options: 
+	  #config_options="--arch=$arch --target-os=mingw32 --cross-prefix=$cross_prefix --pkg-config=pkg-config --enable-gpl --enable-libsoxr --enable-fontconfig --enable-libass --enable-libutvideo --enable-libbluray --enable-iconv --enable-libtwolame --extra-cflags=-DLIBTWOLAME_STATIC --enable-libzvbi --enable-libcaca --enable-libmodplug --extra-libs=-lstdc++ --extra-libs=-lpng --enable-libvidstab --enable-libx265 --enable-decklink --extra-libs=-loleaut32 --enable-libx264 --enable-libxvid --enable-libmp3lame --enable-version3 --enable-zlib --enable-librtmp --enable-libvorbis --enable-libtheora --enable-libspeex --enable-libopenjpeg --enable-gnutls --enable-libgsm --enable-libfreetype --enable-libopus --disable-w32threads --enable-frei0r --enable-filter=frei0r --enable-libvo-aacenc --enable-bzlib --enable-libxavs --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libvo-amrwbenc --enable-libschroedinger --enable-libvpx --enable-libilbc --enable-libwavpack --enable-libwebp --enable-libgme --enable-dxva2 --enable-libdcadec --enable-avisynth $extra_configure_opts" 
+	  # new config options: 
+	  config_options="--arch=$arch --target-os=mingw32 --cross-prefix=$cross_prefix --pkg-config=pkg-config --extra-libs=-lstdc++ --disable-w32threads $extra_configure_opts"
+	  
+
+Now you're ready to run the script. To the question: 
+`Would you like to include non-free (non GPL compatible) libraries`, answer no (N). 
+
+The script takes a while (1-3 hours). The resulting dll files are in <br>
+`sandbox/x86_64/ffmpeg_git_shared.installed/bin/` <br>
+`ffmpeg_git_shared.installed/bin/`
+
+Run ffmpeg.exe to verify that the correct configure options where in fact used. 
+
+
+<i>Sometimes the script fails because sourceforge is having serious downtime issues. I found that it's usually easy to give the script a hand by downloading the correct version of the dependency yourself, then place it in the win32 and x86_64 folders. (or just do a manual git clone if you find a mirror of the code).</i>
+
+Compiling for Linux using Ubuntu
+---
+
+This is directly taken from the [https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu](FFmpeg guide for Ubuntu). The following steps assume a 64bit Ubuntu installation. 
+
+
+	sudo apt-get update
+	
+	sudo apt-get -y --force-yes install git autoconf automake build-essential libass-dev \
+		libfreetype6-dev libsdl1.2-dev libtheora-dev libtool libva-dev libvdpau-dev\
+		libvorbis-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev pkg-config \
+		texi2html zlib1g-dev gcc-multilib libc6-i386
+	
+	git clone git://source.ffmpeg.org/ffmpeg.git
+	cd ffmpeg
+	# check out specific revision if you want
+	./configure  --prefix=`pwd`/dist/x86_64/ --enable-pic --enable-shared
+	make && make install
+	
+	# now cross compile for 32 bit
+	make clean 
+	./configure  --prefix=`pwd`/dist/i386/ --enable-pic --enable-shared --extra-cflags="-m32" --extra-cxxflags="-m32" --extra-ldflags="-m32" --arch=i386
+	make && make install
+	
+	
+Good job! If all goes well you have two directories: `dist/x86_64` and `dist/i386`
+
+
+Special Licensing Considerations
+---
+You can enable aac with the configuration option `--enable-nonfree`. FFmpeg has the following to say about this: 
+
+	The Fraunhofer AAC library, FAAC and aacplus are under licenses which
+	are incompatible with the GPLv2 and v3. We do not know for certain if their
+	licenses are compatible with the LGPL.
+	If you wish to enable these libraries, pass `--enable-nonfree` to configure.
+	But note that if you enable any of these libraries the resulting binary will
+	be under a complex license mix that is more restrictive than the LGPL and that
+	may result in additional obligations. It is possible that these
+	restrictions cause the resulting binary to be unredistributeable.
+
+To enable certain video codecs (like x264) the `--enable-gpl` flag can be added. This means your application will have to be released under the GPL as well. 

--- a/docs/ffmpeg/readme.md
+++ b/docs/ffmpeg/readme.md
@@ -1,0 +1,42 @@
+FFmpeg README
+=============
+
+FFmpeg is a collection of libraries and tools to process multimedia content
+such as audio, video, subtitles and related metadata.
+
+## Libraries
+
+* `libavcodec` provides implementation of a wider range of codecs.
+* `libavformat` implements streaming protocols, container formats and basic I/O access.
+* `libavutil` includes hashers, decompressors and miscellaneous utility functions.
+* `libavfilter` provides a mean to alter decoded Audio and Video through chain of filters.
+* `libavdevice` provides an abstraction to access capture and playback devices.
+* `libswresample` implements audio mixing and resampling routines.
+* `libswscale` implements color conversion and scaling routines.
+
+## Tools
+
+* [ffmpeg](http://ffmpeg.org/ffmpeg.html) is a command line toolbox to
+  manipulate, convert and stream multimedia content.
+* [ffplay](http://ffmpeg.org/ffplay.html) is a minimalistic multimedia player.
+* [ffprobe](http://ffmpeg.org/ffprobe.html) is a simple analysis tool to inspect
+  multimedia content.
+* [ffserver](http://ffmpeg.org/ffserver.html) is a multimedia streaming server
+  for live broadcasts.
+* Additional small tools such as `aviocat`, `ismindex` and `qt-faststart`.
+
+## Documentation
+
+The offline documentation is available in the **doc/** directory.
+
+The online documentation is available in the main [website](http://ffmpeg.org)
+and in the [wiki](http://trac.ffmpeg.org).
+
+### Examples
+
+Coding examples are available in the **doc/examples** directory.
+
+## License
+
+FFmpeg codebase is mainly LGPL-licensed with optional components licensed under
+GPL. Please refer to the LICENSE file for detailed information.

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,8 @@ See scripts/readme.md for the full distribution process.
 
 
 ## License/Source code
-
-* [Openframeworks](http://openframeworks.cc). A creative coding library. The larger part of it is licensed as MIT/BSD. 
-* [FFmpeg](http://www.ffmpeg.org/) and [ofxAvCodec](https://github.com/kritzikratzi/ofxAvCodec). FFmpeg is _the_ encoder/decoder library and licensed under the gpl/lgpl 2.1. The binaries included here were compiled to comply with the lgpl. A copy of the LGPL together with instructions how the library was compiled for each platform can be found in the `legal` folder. 
-* The sourcecode for this application is freely available on [github](https://github.com/kritzikratzi/Oscilloscope). 
+* See [LICENSE](LICENSE) for more information.
+* The sourcecode for this application is freely available on [github](https://github.com/kritzikratzi/Oscilloscope) under the WTFPL license. 
+* Based on [Openframeworks](http://openframeworks.cc). A creative coding library. The larger part of it is licensed as MIT/BSD. 
+* Uses [FFmpeg](http://www.ffmpeg.org/) _(the encoder/decoder library)_ and [ofxAvCodec](https://github.com/kritzikratzi/ofxAvCodec) to encode/decode video/audio files.
+* [FFmpeg](http://www.ffmpeg.org/) is licensed under the gpl/lgpl 2.1. The shared libraries included here were compiled to comply with the lgpl. A copy of the LGPL together with instructions how the library was compiled for each platform can be found in the [docs/ffmpeg](docs/ffmpeg) folder. Alternatively (or if the files were not included by accident) you can find online versions of the compilation instructions and the LGPL as part of the ofxAvCodec project. 


### PR DESCRIPTION
I've adjusted and included the correct license excerpts.
Readme reflecting this.
May want to revert website. (sorry)
Updates #39.
Since ffmpeg docs are in markdown it's best for them to be in the repository.